### PR TITLE
Update: 管理者用ページのトップから現在の収支情報が見れるように更新

### DIFF
--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,11 +1,59 @@
-import { Box, Button, Heading, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Heading, Tab, Text, VStack } from "@chakra-ui/react";
 import Link from "next/link";
 import { UseLoginState } from "@/hooks/UseLoginState";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import prisma from "@/lib/prisma";
 
 export default function Home() {
   const [isAdmin,isUser, Login, Logout] = UseLoginState(false);
   const router = useRouter();
+  const [income,setIncome] = useState(0)
+  const [outcome,setOutcome] = useState(0)
+  const [balance,setBalance] = useState(0)
+  const [hatosaiIncome,setHatosaiIncome] = useState(0)
+  const [hatosaiOutcome,setHatosaiOutcome] = useState(0)
+  const [hatosaiBalance,setHatosaiBalance] = useState(0)
+  const [csIncome,setCSIncome] = useState(0)
+  const [csOutcome,setCSOutcome] = useState(0)
+  const [csBalance,setCSBalance] = useState(0)
+  const [alumniIncome,setAlumniIncome] = useState(0)
+  const [alumniOutcome,setAlumniOutcome] = useState(0)
+  const [alumniBalance,setAlumniBalance] = useState(0)
+  async function getEarngings(sessionToken:string) {
+    let year = new Date().getFullYear()
+    if(new Date().getMonth()+1 < 4){
+      year -1
+    }
+    const sendYear = String(year)
+    const body = {
+      year:sendYear,
+      inputPass:"from admin page",
+      sessionToken
+    }
+    const result = await fetch("/api/database/earnings",{
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      body:JSON.stringify(body)
+    })
+    const res = JSON.parse(await result.json())
+    setIncome(res.income)
+    setOutcome(res.outcome)
+    setBalance(res.balance)
+    setHatosaiIncome(res.hatosaiIncome)
+    setHatosaiOutcome(res.hatosaiOutcome)
+    setHatosaiBalance(res.hatosaiBalance)
+    setCSIncome(res.csIncome)
+    setCSOutcome(res.csOutcome)
+    setCSBalance(res.csBalance)
+    setAlumniIncome(res.alumniIncome)
+    setAlumniOutcome(res.alumniOutcome)
+    setAlumniBalance(res.alumniBalance)
+  }
+  useEffect(()=>{
+    const sessionToken = localStorage.getItem("storage_token")!
+    getEarngings(sessionToken)
+  },[])
   return (
     <>
       <VStack>
@@ -14,7 +62,7 @@ export default function Home() {
             <Text>Log in as : {isAdmin?"管理者":"一般ユーザー"}</Text>
           </> 
         : null}
-        <Text fontSize={"2xl"}>ホーム</Text>
+        <Text fontSize={"2xl"}>管理者用ページホーム</Text>
         {isAdmin || isUser ? (
           <>
             {isAdmin ? 
@@ -36,6 +84,33 @@ export default function Home() {
             </Link>
             </>
             : <Heading>一般ユーザーの権限では使用できません。</Heading> }
+            
+            <Box>
+              <Box margin="5px"  border="1px solid #fc8819" borderRadius={"lg"}>
+                <VStack margin={"5px"}>
+                <Text>現在の本予算収支</Text>
+                <Text>収入:{income}円、支出:{outcome}円、残高:{(balance>=0)?<>{balance}</>:<Text as="span" color="red" fontWeight={"extrabold"}>{balance}</Text>}円</Text>
+                </VStack>
+              </Box>
+              <Box margin="5px"  border="1px solid #1e90ff" borderRadius={"lg"}>
+                <VStack margin={"5px"}>
+                <Text>現在の鳩山祭援助金収支</Text>
+                <Text>収入:{hatosaiIncome}円、支出:{hatosaiOutcome}円、残高:{(hatosaiBalance>=0)?<>{hatosaiBalance}</>:<Text as="span" color="red" fontWeight={"extrabold"}>{hatosaiBalance}</Text>}円</Text>
+                </VStack>
+              </Box>
+              <Box margin="5px"  border="1px solid #32cd32" borderRadius={"lg"}>
+                <VStack margin={"5px"}>
+                <Text>現在の後援会費収支</Text>
+                <Text>収入:{csIncome}円、支出:{csOutcome}円、残高:{(csBalance>=0)?<>{csBalance}</>:<Text as="span" color="red" fontWeight={"extrabold"}>{csBalance}</Text>}円</Text>
+                </VStack>
+              </Box>
+              <Box margin="5px" border="1px solid #0000cd" borderRadius={"lg"}>
+                <VStack margin={"5px"}>
+                <Text>現在の校友会費収支</Text>
+                <Text>収入:{alumniIncome}円、支出:{alumniOutcome}円、残高:{(alumniBalance>=0)?<>{alumniBalance}</>:<Text as="span" color="red" fontWeight={"extrabold"}>{alumniBalance}</Text>}円</Text>
+                </VStack>
+              </Box>
+            </Box>
             <Button onClick={Logout}>ログアウト</Button>
           </>
         ) : (

--- a/src/pages/api/database/earnings.ts
+++ b/src/pages/api/database/earnings.ts
@@ -14,15 +14,27 @@ export default async function handle(
     body: {
       year: string;
       inputPass: string;
+      sessionToken: string;
     };
   },
   res: NextApiResponse
 ) {
   const pass = process.env.EARNINGPASS
-  const {year,inputPass} = req.body
-  if(inputPass){
+  const {year,inputPass,sessionToken} = req.body
+  let isAdmin:boolean = false
+  const data = await prisma.tokens.findFirst({
+    where:{
+      tokens:sessionToken
+    }
+  });
+  if(data){
+    if(data.limit > new Date()){
+      isAdmin = data.isAdmin
+    }
+  }
+  if(inputPass || sessionToken){
     const hashPass = encryptSha256(inputPass)
-    if(pass == hashPass) {
+    if(pass == hashPass || isAdmin) {
       const result = await prisma.mainAccount.findMany({
         where: {
           year: year
@@ -35,7 +47,43 @@ export default async function handle(
         outcome += result[i].outcome
       }
       var balance = income-outcome
-      var response = {"income":income,"outcome":outcome,"balance":balance}
+      const hatoyamaResult = await prisma.hatosaiAccount.findMany({
+        where: {
+          year: year
+        }
+      });
+      let hatoyamaIncome:number = 0;
+      let hatoyamaOutcome: number = 0;
+      for(var i=0;i<hatoyamaResult.length;i++){
+        hatoyamaIncome += hatoyamaResult[i].income
+        hatoyamaOutcome += hatoyamaResult[i].outcome
+      }
+      var hatoyamaBalance = hatoyamaIncome-hatoyamaOutcome
+      const csResult = await prisma.clubsupportAccount.findMany({
+        where: {
+          year: year
+        }
+      });
+      let csIncome:number = 0;
+      let csOutcome: number = 0;
+      for(var i=0;i<csResult.length;i++){
+        csIncome += csResult[i].income
+        csOutcome += csResult[i].outcome
+      }
+      var csBalance = csIncome-csOutcome
+      const alumniResult = await prisma.alumniAccount.findMany({
+        where: {
+          year: year
+        }
+      });
+      let alumniIncome:number = 0;
+      let alumniOutcome: number = 0;
+      for(var i=0;i<alumniResult.length;i++){
+        alumniIncome += alumniResult[i].income
+        alumniOutcome += alumniResult[i].outcome
+      }
+      var alumniBalance = alumniIncome-alumniOutcome
+      var response = {"income":income,"outcome":outcome,"balance":balance,"hatosaiIncome":hatoyamaIncome,"hatosaiOutcome":hatoyamaOutcome,"hayosaiBalance":hatoyamaBalance,"csIncome":csIncome,"csOutcome":csOutcome,"csBalance":csBalance,"alumniIncome":alumniIncome,"alumniOutcome":alumniOutcome,"alumniBalance":alumniBalance}
       var send_string = JSON.stringify(response)
       res.status(200).json(send_string);
     }

--- a/src/pages/api/database/earnings.ts
+++ b/src/pages/api/database/earnings.ts
@@ -83,7 +83,7 @@ export default async function handle(
         alumniOutcome += alumniResult[i].outcome
       }
       var alumniBalance = alumniIncome-alumniOutcome
-      var response = {"income":income,"outcome":outcome,"balance":balance,"hatosaiIncome":hatoyamaIncome,"hatosaiOutcome":hatoyamaOutcome,"hayosaiBalance":hatoyamaBalance,"csIncome":csIncome,"csOutcome":csOutcome,"csBalance":csBalance,"alumniIncome":alumniIncome,"alumniOutcome":alumniOutcome,"alumniBalance":alumniBalance}
+      var response = {"income":income,"outcome":outcome,"balance":balance,"hatosaiIncome":hatoyamaIncome,"hatosaiOutcome":hatoyamaOutcome,"hatosaiBalance":hatoyamaBalance,"csIncome":csIncome,"csOutcome":csOutcome,"csBalance":csBalance,"alumniIncome":alumniIncome,"alumniOutcome":alumniOutcome,"alumniBalance":alumniBalance}
       var send_string = JSON.stringify(response)
       res.status(200).json(send_string);
     }


### PR DESCRIPTION
- - 管理者用ページのトップから、本予算、鳩山祭援助金、後援会費、校友会費の各収支状況を見れるように更新