### PR TITLE
Update: 物品名入力欄をInputに変更

### DIFF
--- a/src/pages/alumni/income.tsx
+++ b/src/pages/alumni/income.tsx
@@ -147,7 +147,7 @@ export default function Home() {
             </FormControl>
             <FormControl>
               <FormLabel>収入事由</FormLabel>
-              <Textarea onChange={(e) => setFixture(e.target.value)} />
+              <Input onChange={(e) => setFixture(e.target.value)} />
             </FormControl>
             <FormControl>
               <FormLabel>メモ</FormLabel>

--- a/src/pages/alumni/outcome.tsx
+++ b/src/pages/alumni/outcome.tsx
@@ -326,7 +326,7 @@ const Home: NextPage = () => {
             </FormControl>
             <FormControl>
               <FormLabel>購入物品名</FormLabel>
-              <Textarea onChange={(e) => setFixture(e.target.value)} />
+              <Input onChange={(e) => setFixture(e.target.value)} />
             </FormControl>
             <FormControl>
               <FormLabel>メモ</FormLabel>

--- a/src/pages/clubsupport/income.tsx
+++ b/src/pages/clubsupport/income.tsx
@@ -147,7 +147,7 @@ export default function Home() {
             </FormControl>
             <FormControl>
               <FormLabel>収入事由</FormLabel>
-              <Textarea onChange={(e) => setFixture(e.target.value)} />
+              <Input onChange={(e) => setFixture(e.target.value)} />
             </FormControl>
             <FormControl>
               <FormLabel>メモ</FormLabel>

--- a/src/pages/clubsupport/outcome.tsx
+++ b/src/pages/clubsupport/outcome.tsx
@@ -326,7 +326,7 @@ const Home: NextPage = () => {
             </FormControl>
             <FormControl>
               <FormLabel>購入物品名</FormLabel>
-              <Textarea onChange={(e) => setFixture(e.target.value)} />
+              <Input onChange={(e) => setFixture(e.target.value)} />
             </FormControl>
             <FormControl>
               <FormLabel>メモ</FormLabel>

--- a/src/pages/hatosai/income.tsx
+++ b/src/pages/hatosai/income.tsx
@@ -147,7 +147,7 @@ export default function Home() {
             </FormControl>
             <FormControl>
               <FormLabel>収入事由</FormLabel>
-              <Textarea onChange={(e) => setFixture(e.target.value)} />
+              <Input onChange={(e) => setFixture(e.target.value)} />
             </FormControl>
             <FormControl>
               <FormLabel>メモ</FormLabel>

--- a/src/pages/hatosai/outcome.tsx
+++ b/src/pages/hatosai/outcome.tsx
@@ -326,7 +326,7 @@ const Home: NextPage = () => {
             </FormControl>
             <FormControl>
               <FormLabel>購入物品名</FormLabel>
-              <Textarea onChange={(e) => setFixture(e.target.value)} />
+              <Input onChange={(e) => setFixture(e.target.value)} />
             </FormControl>
             <FormControl>
               <FormLabel>メモ</FormLabel>

--- a/src/pages/income/index.tsx
+++ b/src/pages/income/index.tsx
@@ -147,7 +147,7 @@ export default function Home() {
               </FormControl>
               <FormControl>
                 <FormLabel>収入事由</FormLabel>
-                <Textarea onChange={(e) => setFixture(e.target.value)} />
+                <Input onChange={(e) => setFixture(e.target.value)} />
               </FormControl>
               <FormControl>
                 <FormLabel>メモ</FormLabel>

--- a/src/pages/outcome/index.tsx
+++ b/src/pages/outcome/index.tsx
@@ -326,7 +326,7 @@ const Home: NextPage = () => {
             </FormControl>
             <FormControl>
               <FormLabel>購入物品名</FormLabel>
-              <Textarea onChange={(e) => setFixture(e.target.value)} />
+              <Input onChange={(e) => setFixture(e.target.value)} />
             </FormControl>
             <FormControl>
               <FormLabel>メモ</FormLabel>


### PR DESCRIPTION
- 収入、支出報告ページの物品名入力欄がTextareaだと途中で改行が挟まれ、excelの決算作成時にセル内に改行が挟まれてしまうため、Inputに変更。